### PR TITLE
Feature/context menu 미완성

### DIFF
--- a/MemoWithTags/MemoWithTags/AppEnvironment/States/NavigationState.swift
+++ b/MemoWithTags/MemoWithTags/AppEnvironment/States/NavigationState.swift
@@ -11,6 +11,7 @@ enum Route: Hashable {
     case root
     case main
     case search
+    case memoEditor
     
     //MARK: - 로그인
     case login

--- a/MemoWithTags/MemoWithTags/Presentation/View/AppRootView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/AppRootView.swift
@@ -44,6 +44,8 @@ struct AppRootView: View {
                         MainView(viewModel: mainViewModel)
                     case .search:
                         SearchView(viewModel: mainViewModel)
+                    case .memoEditor:
+                        MemoEditorView(viewModel: mainViewModel)
                         
                     //MARK: - 로그인
                     case .login:

--- a/MemoWithTags/MemoWithTags/Presentation/View/Pages/MainView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/Pages/MainView.swift
@@ -30,7 +30,6 @@ struct MainView: View {
                     EditingTagListView(viewModel: viewModel)
                 }
             }
-
         }
         .onAppear {
             Task {
@@ -38,7 +37,7 @@ struct MainView: View {
             }
         }
         .toolbar {
-            // 로고
+            //MARK: - 로고
             ToolbarItem(placement: .topBarLeading) {
                 HStack(spacing: 3) {
                     Text("Memo with")
@@ -49,7 +48,7 @@ struct MainView: View {
                 }
             }
             
-            // 서치, 설정 창 버튼
+            //MARK: - 서치, 설정 창 버튼
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 14) {
                     Image(systemName: "magnifyingglass")

--- a/MemoWithTags/MemoWithTags/Presentation/View/Pages/MemoEditorView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/Pages/MemoEditorView.swift
@@ -5,24 +5,23 @@
 //  Created by 최진모 on 1/24/25.
 //
 import SwiftUI
-import RichTextKit
 import Flow
 
 struct MemoEditorView: View {
-    @Environment(\.dismiss) var dismiss
     @ObservedObject var viewModel: MainViewModel
 
     @StateObject var keyboardManager = KeyboardManager()
     
     var body: some View {
         VStack(spacing: 0) {
+            //MARK: - 상단 바
             HStack {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 19, weight: .regular))
                     .foregroundStyle(Color.black)
                     .onTapGesture {
                         Task {
-                            dismiss()
+                            viewModel.appState.navigation.pop()
                             await viewModel.submit()
                         }
                     }
@@ -34,7 +33,7 @@ struct MemoEditorView: View {
                         viewModel.editorState = .create
                         viewModel.editorContent = ""
                         viewModel.editorTagIds = []
-                        dismiss()
+                        viewModel.appState.navigation.pop()
                     } label: {
                         Label("변경사항 삭제하기", systemImage: "trash")
                     }
@@ -54,6 +53,7 @@ struct MemoEditorView: View {
             
             Divider()
             
+            //MARK: - 메모 에디터
             TextEditor(text: $viewModel.editorContent)
                 .overlay(Group { // placeholder
                     if viewModel.editorContent.isEmpty {
@@ -67,6 +67,7 @@ struct MemoEditorView: View {
             
             Spacer()
             
+            //MARK: - 날짜, 잠금 상태 표시
             HStack {
                 switch viewModel.editorState {
                 case .create:
@@ -91,9 +92,8 @@ struct MemoEditorView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
-
-
             
+            //MARK: - 메모 내 태그들
             HFlow {
                 ForEach(viewModel.getTags(from: viewModel.editorTagIds), id: \.id) { tag in
                     TagView(viewModel: viewModel, tag: tag, addXmark: true) {
@@ -108,6 +108,7 @@ struct MemoEditorView: View {
                 EditingTagListView(viewModel: viewModel)
             }
         }
+        .navigationBarBackButtonHidden()
     }
     
     private func removeTagFromSelectedTags(_ tagId: Int) {

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/CustomContextMenu.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/CustomContextMenu.swift
@@ -9,16 +9,30 @@ import SwiftUI
 
 struct CustomContextMenu: ViewModifier {
     @Binding var isPresented: Bool
-    let menuContent: () -> AnyView
     
     @State private var frame: CGRect = .zero
     
     func body(content: Content) -> some View {
+        content
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear {
+                            self.frame = proxy.frame(in: .global)
+                        }
+                        .onChange(of: proxy.frame(in: .global)) {
+                            self.frame = proxy.frame(in: .global)
+                        }
+                }
+            )
+            .onLongPressGesture {
+                isPresented.toggle()
+            }
     }
 }
 
 extension View {
-    func customContextMenu(isPresented: Binding<Bool>, @ViewBuilder menuContent: @escaping () -> AnyView) -> some View {
-        self.modifier(CustomContextMenu(isPresented: isPresented, menuContent: menuContent))
+    func customContextMenu(isPresented: Binding<Bool>) -> some View {
+        self.modifier(CustomContextMenu(isPresented: isPresented))
     }
 }

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/CustomContextMenu.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/CustomContextMenu.swift
@@ -9,8 +9,12 @@ import SwiftUI
 
 struct CustomContextMenu: ViewModifier {
     @Binding var isPresented: Bool
+    let Preview: () -> AnyView
+    let Contextmenu: () -> AnyView
     
     @State private var frame: CGRect = .zero
+    
+    @State private var appearEffect = false
     
     func body(content: Content) -> some View {
         content
@@ -28,11 +32,60 @@ struct CustomContextMenu: ViewModifier {
             .onLongPressGesture {
                 isPresented.toggle()
             }
+            .fullScreenCover(isPresented: $isPresented) {
+                ZStack {
+                    BackdropBlurView(radius: 10)
+                        .onTapGesture {
+                            isPresented.toggle()
+                        }
+                    
+                    VStack(spacing: 15) {
+                        Preview()
+                            .shadow(color: Color.black.opacity(0.2), radius: 6, x: 0, y: 2)
+                        Contextmenu()
+                            .shadow(color: Color.black.opacity(0.1), radius: 6, x: 0, y: 2)
+                    }
+                }
+                .presentationBackground(.black.opacity(0.1))
+                .transaction { transaction in
+                    transaction.disablesAnimations = false
+                }
+            }
+            .transaction { transaction in
+                transaction.disablesAnimations = true
+            }
     }
 }
 
 extension View {
-    func customContextMenu(isPresented: Binding<Bool>) -> some View {
-        self.modifier(CustomContextMenu(isPresented: isPresented))
+    func customContextMenu(isPresented: Binding<Bool>, @ViewBuilder preview: @escaping () -> AnyView, @ViewBuilder contextmenu: @escaping () -> AnyView) -> some View {
+        self.modifier(CustomContextMenu(isPresented: isPresented, Preview: preview, Contextmenu: contextmenu))
     }
+}
+
+//MARK: - 배경 블러
+struct BackdropView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIVisualEffectView {
+        let view = UIVisualEffectView()
+        let blur = UIBlurEffect()
+        let animator = UIViewPropertyAnimator()
+        animator.addAnimations { view.effect = blur }
+        animator.fractionComplete = 0
+        animator.stopAnimation(false)
+        animator.finishAnimation(at: .current)
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIVisualEffectView, context: Context) { }
+}
+
+struct BackdropBlurView: View {
+    
+    let radius: CGFloat
+    
+    @ViewBuilder
+    var body: some View {
+        BackdropView().blur(radius: radius)
+    }
+    
 }

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/CustomContextMenu.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/CustomContextMenu.swift
@@ -12,23 +12,8 @@ struct CustomContextMenu: ViewModifier {
     let Preview: () -> AnyView
     let Contextmenu: () -> AnyView
     
-    @State private var frame: CGRect = .zero
-    
-    @State private var appearEffect = false
-    
     func body(content: Content) -> some View {
         content
-            .background(
-                GeometryReader { proxy in
-                    Color.clear
-                        .onAppear {
-                            self.frame = proxy.frame(in: .global)
-                        }
-                        .onChange(of: proxy.frame(in: .global)) {
-                            self.frame = proxy.frame(in: .global)
-                        }
-                }
-            )
             .onLongPressGesture {
                 isPresented.toggle()
             }
@@ -56,7 +41,6 @@ struct CustomContextMenu: ViewModifier {
             }
     }
 }
-
 extension View {
     func customContextMenu(isPresented: Binding<Bool>, @ViewBuilder preview: @escaping () -> AnyView, @ViewBuilder contextmenu: @escaping () -> AnyView) -> some View {
         self.modifier(CustomContextMenu(isPresented: isPresented, Preview: preview, Contextmenu: contextmenu))

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/EditingMemoView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/EditingMemoView.swift
@@ -7,15 +7,11 @@
 
 import SwiftUI
 import Flow
-import RichTextKit
 
 struct EditingMemoView: View {
     @ObservedObject var viewModel: MainViewModel
     
-    @Namespace var namespace
-    
     @State var dynamicHeight: CGFloat = 40
-    @StateObject var context = RichTextContext()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -54,6 +50,7 @@ struct EditingMemoView: View {
                         .font(.system(size: 17, weight: .regular))
                         .foregroundColor(.dateGray)
                         .onTapGesture {
+                            viewModel.appState.navigation.push(to: .memoEditor)
                         }
                     
                     Spacer()

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/MemoView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/MemoView.swift
@@ -116,7 +116,6 @@ struct MemoView: View {
         .padding(.horizontal, 17)
         .background(Color.memoBackgroundWhite)
         .clipShape(RoundedRectangle(cornerRadius: 14))
-        .matchedTransitionSource(id: "editor\(memo.id)", in: namespace)
         .shadow(color: Color.black.opacity(0.06), radius: 6, x: 0, y: 2)
         //MARK: - 메모 터치했을 때 동작 (메모 잠금해제, 메모 펼치기, 메모 완전 확장)
         .onTapGesture {
@@ -140,49 +139,45 @@ struct MemoView: View {
                 showFullScreenEditor = true
             }
         }
+        .customContextMenu(isPresented: $isMenuVisible)
         //MARK: - context menu
-        .contextMenu {
-            Button {
-                Task {
-                    let authenticated = await BioAuthenticationManager.shared.authenticateUser(reason: "메모를 잠그거나 잠금 해제하려면 인증이 필요합니다.")
-                    if authenticated {
-                        await viewModel.updateMemo(memoId: memo.id, content: memo.content, tagIds: memo.tagIds, locked: !memo.locked)
-                    }
-                }
-            } label: {
-                if memo.locked {
-                    Label("잠금 해제", systemImage: "lock.open")
-                } else {
-                    Label("메모 잠금", systemImage: "lock")
-                }
-            }
-            // searchView에서만 나타나는 추가 메뉴 항목: 메인 페이지에서 해당 메모 보기
-            if viewModel.appState.navigation.current == .search {
-                Button {
-                    // 메인 페이지로 돌아갑니다.
-                    viewModel.appState.navigation.pop()
-                    // 이 부분을 새로 구현해야 한다.
-                } label: {
-                    Label("이 메모를 메인 화면에서 보기", systemImage: "arrow.left")
-                }
-            }
-            
-            Button(role: .destructive) {
-                Task {
-                    await viewModel.deleteMemo(memoId: memo.id)
-                }
-
-            } label: {
-                Label("메모 삭제", systemImage: "trash")
-            }
-        }
-        .fullScreenCover(isPresented: $showFullScreenEditor) {
-            MemoEditorView(viewModel: viewModel)
-                .navigationTransition(.zoom(sourceID: "editor\(memo.id)", in: namespace))
-                .interactiveDismissDisabled()
-        }
+//        .contextMenu {
+//            Button {
+//                Task {
+//                    let authenticated = await BioAuthenticationManager.shared.authenticateUser(reason: "메모를 잠그거나 잠금 해제하려면 인증이 필요합니다.")
+//                    if authenticated {
+//                        await viewModel.updateMemo(memoId: memo.id, content: memo.content, tagIds: memo.tagIds, locked: !memo.locked)
+//                    }
+//                }
+//            } label: {
+//                if memo.locked {
+//                    Label("잠금 해제", systemImage: "lock.open")
+//                } else {
+//                    Label("메모 잠금", systemImage: "lock")
+//                }
+//            }
+//            // searchView에서만 나타나는 추가 메뉴 항목: 메인 페이지에서 해당 메모 보기
+//            if viewModel.appState.navigation.current == .search {
+//                Button {
+//                    // 메인 페이지로 돌아갑니다.
+//                    viewModel.appState.navigation.pop()
+//                    // 이 부분을 새로 구현해야 한다.
+//                } label: {
+//                    Label("이 메모를 메인 화면에서 보기", systemImage: "arrow.left")
+//                }
+//            }
+//            
+//            Button(role: .destructive) {
+//                Task {
+//                    await viewModel.deleteMemo(memoId: memo.id)
+//                }
+//
+//            } label: {
+//                Label("메모 삭제", systemImage: "trash")
+//            }
+//        }
         .padding(.horizontal, 12)
-
+//
     }
     
     func dateFormat(date: Date) -> String {

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/MemoView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/MemoView.swift
@@ -139,45 +139,93 @@ struct MemoView: View {
                 showFullScreenEditor = true
             }
         }
-        .customContextMenu(isPresented: $isMenuVisible)
         //MARK: - context menu
-//        .contextMenu {
-//            Button {
-//                Task {
-//                    let authenticated = await BioAuthenticationManager.shared.authenticateUser(reason: "메모를 잠그거나 잠금 해제하려면 인증이 필요합니다.")
-//                    if authenticated {
-//                        await viewModel.updateMemo(memoId: memo.id, content: memo.content, tagIds: memo.tagIds, locked: !memo.locked)
-//                    }
-//                }
-//            } label: {
-//                if memo.locked {
-//                    Label("잠금 해제", systemImage: "lock.open")
-//                } else {
-//                    Label("메모 잠금", systemImage: "lock")
-//                }
-//            }
-//            // searchView에서만 나타나는 추가 메뉴 항목: 메인 페이지에서 해당 메모 보기
-//            if viewModel.appState.navigation.current == .search {
-//                Button {
-//                    // 메인 페이지로 돌아갑니다.
-//                    viewModel.appState.navigation.pop()
-//                    // 이 부분을 새로 구현해야 한다.
-//                } label: {
-//                    Label("이 메모를 메인 화면에서 보기", systemImage: "arrow.left")
-//                }
-//            }
-//            
-//            Button(role: .destructive) {
-//                Task {
-//                    await viewModel.deleteMemo(memoId: memo.id)
-//                }
-//
-//            } label: {
-//                Label("메모 삭제", systemImage: "trash")
-//            }
-//        }
+        .customContextMenu(isPresented: $isMenuVisible) {
+            //MARK: - 꾹 눌렀을 때 나오는 프리뷰
+            AnyView(
+                VStack(alignment: .center, spacing: 0) {
+                    Text(memo.content)
+                        .foregroundColor(Color.memoTextBlack)
+                        .lineLimit(3)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                    
+                    if !memo.tagIds.isEmpty || memo.locked {
+                        HFlow {
+                            ForEach(viewModel.getTags(from: memo.tagIds), id: \.id) { tag in
+                                TagView(viewModel: viewModel, tag: tag)
+                            }
+                            
+                            if memo.locked {
+                                Image(systemName: "lock.fill")
+                                    .foregroundColor(Color.lockIconGray)
+                                    .font(.system(size: 14))
+                            }
+                        }
+                        .padding(.top, 6)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.top, 9)
+                .padding(.bottom, 12)
+                .padding(.horizontal, 17)
+                .background(Color.memoBackgroundWhite)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .padding(.horizontal, 12)
+            )
+        } contextmenu: {
+            //MARK: - 메뉴
+            AnyView(
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text(memo.locked ? "잠금 해제" : "메모 잠금")
+                        Spacer()
+                        Image(systemName: memo.locked ? "lock.open" : "lock")
+                    }
+                    .onTapGesture {
+                        Task {
+                            let authenticated = await BioAuthenticationManager.shared.authenticateUser(reason: "메모를 잠그거나 잠금 해제하려면 인증이 필요합니다.")
+                            if authenticated {
+                                await viewModel.updateMemo(memoId: memo.id, content: memo.content, tagIds: memo.tagIds, locked: !memo.locked)
+                            }
+                        }
+                    }
+                    
+                    Divider()
+                    
+                    if viewModel.appState.navigation.current == .search {
+                        HStack {
+                            Text("이 메모를 메인 화면에서 보기")
+                            Spacer()
+                            Image(systemName: "arrow.left")
+                        }
+                        .onTapGesture {
+                            // 메인 페이지로 돌아갑니다.
+                            viewModel.appState.navigation.pop()
+                            // 이 부분을 새로 구현해야 한다.
+                        }
+                        
+                        Divider()
+                    }
+                    
+                    HStack {
+                        Text("메모 삭제")
+                        Spacer()
+                        Image(systemName: "trash")
+                    }
+                    .onTapGesture {
+                        Task {
+                            await viewModel.deleteMemo(memoId: memo.id)
+                        }
+                    }
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
+                .background(Color.memoBackgroundWhite)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .frame(width: 250)
+            )
+        }
         .padding(.horizontal, 12)
-//
     }
     
     func dateFormat(date: Date) -> String {

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/MemoView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/MemoView.swift
@@ -13,9 +13,6 @@ struct MemoView: View {
     @ObservedObject var viewModel: MainViewModel
     
     @State private var isExpanded: Bool = false
-    @Namespace var namespace
-    @State private var showFullScreenEditor: Bool = false
-  
     @State private var isMenuVisible = false
     
     var body: some View {
@@ -136,7 +133,7 @@ struct MemoView: View {
                 viewModel.editorState = .update(target: memo)
                 viewModel.editorContent = memo.content
                 viewModel.editorTagIds = memo.tagIds
-                showFullScreenEditor = true
+                viewModel.appState.navigation.push(to: .memoEditor)
             }
         }
         //MARK: - context menu
@@ -147,6 +144,7 @@ struct MemoView: View {
                     Text(memo.content)
                         .foregroundColor(Color.memoTextBlack)
                         .lineLimit(3)
+                        .blur(radius: memo.locked && !viewModel.appState.user.isBioAuthenticated ? 6 : 0)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                     
                     if !memo.tagIds.isEmpty || memo.locked {

--- a/MemoWithTags/MemoWithTags/Presentation/View/SubView/TagView.swift
+++ b/MemoWithTags/MemoWithTags/Presentation/View/SubView/TagView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TagView: View {
     @ObservedObject var viewModel: MainViewModel
     @State private var isUpdating: Bool = false
+    @State private var isMenuVisible = false
     
     var tag: Tag
     var addXmark: Bool = false
@@ -38,31 +39,66 @@ struct TagView: View {
             .onTapGesture {
                 onTap?()
             }
-            .contextMenu {
-                Button(action: {
-                    viewModel.clearSearch()
-                    viewModel.searchBarSelectedTagIds.append(tag.id)
-                    // 현재 뷰가 search가 아닌 경우에만 searchPage로 이동
-                    if viewModel.appState.navigation.current != .search {
-                        viewModel.appState.navigation.push(to: .search)
+            .customContextMenu(isPresented: $isMenuVisible) {
+                AnyView(
+                    Text(tag.name)
+                        .font(.system(size: 15, weight: .regular))
+                        .foregroundColor(Color.tagTextColor)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 1)
+                        .background(tag.color.color)
+                        .cornerRadius(4)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .scaleEffect(1.4)
+                )
+            } contextmenu: {
+                AnyView(
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text("이 태그로 검색하기")
+                            Spacer()
+                            Image(systemName: "magnifyingglass")
+                        }
+                        .onTapGesture {
+                            viewModel.clearSearch()
+                            viewModel.searchBarSelectedTagIds.append(tag.id)
+                            // 현재 뷰가 search가 아닌 경우에만 searchPage로 이동
+                            if viewModel.appState.navigation.current != .search {
+                                viewModel.appState.navigation.push(to: .search)
+                            }
+                        }
+                        
+                        Divider()
+                        
+                        HStack {
+                            Text("태그 수정")
+                            Spacer()
+                            Image(systemName: "pencil")
+                        }
+                        .onTapGesture {
+                            isUpdating = true
+                        }
+                        
+                        Divider()
+                        
+                        HStack {
+                            Text("태그 삭제")
+                            Spacer()
+                            Image(systemName: "trash")
+                        }
+                        .onTapGesture {
+                            Task {
+                                await viewModel.deleteTag(tagId: tag.id)
+                            }
+                        }
                     }
-                }) {
-                    Label("이 태그로 검색하기", systemImage: "magnifyingglass")
-                }
-                
-                Button {
-                    isUpdating = true
-                } label: {
-                    Label("수정", systemImage: "pencil")
-                }
-                
-                Button(role: .destructive) {
-                    Task {
-                        await viewModel.deleteTag(tagId: tag.id)
-                    }
-                } label: {
-                    Label("삭제", systemImage: "trash")
-                }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .background(Color.memoBackgroundWhite)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .frame(width: 250)
+                )
             }
             .sheet(isPresented: $isUpdating, onDismiss: {
                 isUpdating = false


### PR DESCRIPTION
일단 context menu를 직접 한땀 한땀 만들어보려 했는데 많은 어려움이 있어서 아직 방법을 못찾는 중..
현재 context menu 상황
<img src="https://github.com/user-attachments/assets/bddb247b-1570-4648-b1ac-0d357972df47" width=300/>
이 사진처럼 뜨는데 일단

> 꾹 누름 -> fullscreencover를 띄움 -> 배경화면에 블러처리 -> preview와 contextmenu를 보여줌

이런 방식으로 구현되어 있는데
현재는 저것들은 원래 메모가 있던 위치 바로 위에 띄워지는게 아니라 무조건  화면 한 가운데 표시되게 해두었어.
원래 메모 있던 위치 바로 위에 띄우는 거는 많은 방법을 찾아봤는데 아직 해결하지 못했어

근데 이 방식이 다른 버그들도 많아서...일단 어떻게 해야 할지 잘 모르겠는 중

저렇게 fullscreencover로 띄우는 것 말고도 .overlay( ... ) 같은 걸로 간편하게 구현하는 방법도 있긴 하겠지만,
일단 메뉴와 꾹 누른 타겟이 눈에 잘 보여야 하는 점도 있고
메뉴가 화면 바깥으로 나가는 경우, 메모가 화면을 넘어설 만큼 긴 경우, 태그를 꾹 눌렀을 때도 동일하게 동작해야하는 점 등등을 고려해야 해서 좀 머리가 아플듯..

일단 다른 방법도 조금 시도해볼게